### PR TITLE
Add example server and Docker usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ A production-ready, pluggable token bucket rate limiter written in Go. Built wit
 
 ---
 
+## 🔧 Prerequisites
+
+* **Go** 1.24 or newer
+* **Docker** and **docker-compose** for containerized runs
+
+---
+
 ## 📦 Installation
 
 ```bash
@@ -63,6 +70,28 @@ Distributed-Rate-Limiter/
 ├── go.mod
 └── README.md
 ```
+
+---
+
+## ▶️ Running the Example Server
+
+### Local execution
+
+```bash
+go run examples/main.go
+```
+
+Open `http://localhost:8080/ping` in your browser or via curl to test.
+
+### Docker Compose
+
+Build and run the containerized server:
+
+```bash
+docker-compose up --build
+```
+
+The service exposes port **8080** on the host.
 
 ---
 


### PR DESCRIPTION
## Summary
- document Go/Docker prerequisites
- explain how to run the example server directly
- show how to build and run with docker-compose

## Testing
- `go vet ./...` *(fails: fetching modules not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_6843d9edbd5c83288cdecac6cdae9af2